### PR TITLE
10 support custom sendingtime format

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,2 @@
 * Fixed an exception when adding custom fields.
+* The format of outgoing timestamp fields can now be customised in the session properties dialog.

--- a/Fix.Tests/SessionTests.cs
+++ b/Fix.Tests/SessionTests.cs
@@ -1307,7 +1307,7 @@ public class SessionTests : SessionTestsBase<Fix.Session>
     [TestMethod]
     public void TestMillisecondTimestampsEnabled()
     {
-        Acceptor.MillisecondTimestamps = true;
+        Acceptor.OutgoingTimestampFormat = Fix.Field.TimestampFormatLong;
 
         Assert.AreEqual(Fix.State.Connected, Acceptor.State);
         Assert.AreEqual(Fix.State.Connected, Initiator.State);
@@ -1335,7 +1335,7 @@ public class SessionTests : SessionTestsBase<Fix.Session>
     [TestMethod]
     public void TestMillisecondTimestampsDisabled()
     {
-        Acceptor.MillisecondTimestamps = false;
+        Acceptor.OutgoingTimestampFormat = Fix.Field.TimestampFormatShort;
 
         Assert.AreEqual(Fix.State.Connected, Acceptor.State);
         Assert.AreEqual(Fix.State.Connected, Initiator.State);
@@ -1372,7 +1372,7 @@ public class SessionTests : SessionTestsBase<Fix.Session>
             SenderCompId = "SENDER",
             TargetCompId = "TARGET",
             HeartBtInt = 30,
-            MillisecondTimestamps = true,
+            OutgoingTimestampFormat = Fix.Field.TimestampFormatLong,
             IncomingSeqNum = 1,
             OutgoingSeqNum = 1,
             BrokenNewSeqNo = true,
@@ -1390,7 +1390,7 @@ public class SessionTests : SessionTestsBase<Fix.Session>
         clone.SenderCompId = "INITIATOR";
         clone.TargetCompId = "ACCEPTOR";
         clone.HeartBtInt = 60;
-        clone.MillisecondTimestamps = false;
+        clone.OutgoingTimestampFormat = Fix.Field.TimestampFormatShort;
         clone.IncomingSeqNum = 2;
         clone.OutgoingSeqNum = 2;
         clone.BrokenNewSeqNo = false;
@@ -1405,7 +1405,7 @@ public class SessionTests : SessionTestsBase<Fix.Session>
         Assert.AreEqual("SENDER", original.SenderCompId);
         Assert.AreEqual("TARGET", original.TargetCompId);
         Assert.AreEqual(30, original.HeartBtInt);
-        Assert.AreEqual(true, original.MillisecondTimestamps);
+        Assert.AreEqual(Fix.Field.TimestampFormatLong, original.OutgoingTimestampFormat);
         Assert.AreEqual(1, original.IncomingSeqNum);
         Assert.AreEqual(1, original.OutgoingSeqNum);
         Assert.AreEqual(true, original.BrokenNewSeqNo);
@@ -1420,7 +1420,7 @@ public class SessionTests : SessionTestsBase<Fix.Session>
         Assert.AreEqual("INITIATOR", clone.SenderCompId);
         Assert.AreEqual("ACCEPTOR", clone.TargetCompId);
         Assert.AreEqual(60, clone.HeartBtInt);
-        Assert.AreEqual(false, clone.MillisecondTimestamps);
+        Assert.AreEqual(Fix.Field.TimestampFormatShort, clone.OutgoingTimestampFormat);
         Assert.AreEqual(2, clone.IncomingSeqNum);
         Assert.AreEqual(2, clone.OutgoingSeqNum);
         Assert.AreEqual(false, clone.BrokenNewSeqNo);
@@ -1441,7 +1441,7 @@ public class SessionTests : SessionTestsBase<Fix.Session>
             SenderCompId = "SENDER",
             TargetCompId = "TARGET",
             HeartBtInt = 30,
-            MillisecondTimestamps = true,
+            OutgoingTimestampFormat = Fix.Field.TimestampFormatLong,
             IncomingSeqNum = 1,
             OutgoingSeqNum = 1,
             BrokenNewSeqNo = true,
@@ -1460,7 +1460,7 @@ public class SessionTests : SessionTestsBase<Fix.Session>
         clone.SenderCompId = "INITIATOR";
         clone.TargetCompId = "ACCEPTOR";
         clone.HeartBtInt = 60;
-        clone.MillisecondTimestamps = false;
+        clone.OutgoingTimestampFormat = Fix.Field.TimestampFormatShort;
         clone.IncomingSeqNum = 2;
         clone.OutgoingSeqNum = 2;
         clone.BrokenNewSeqNo = false;
@@ -1476,7 +1476,7 @@ public class SessionTests : SessionTestsBase<Fix.Session>
         Assert.AreEqual("SENDER", original.SenderCompId);
         Assert.AreEqual("TARGET", original.TargetCompId);
         Assert.AreEqual(30, original.HeartBtInt);
-        Assert.AreEqual(true, original.MillisecondTimestamps);
+        Assert.AreEqual(Fix.Field.TimestampFormatLong, original.OutgoingTimestampFormat);
         Assert.AreEqual(1, original.IncomingSeqNum);
         Assert.AreEqual(1, original.OutgoingSeqNum);
         Assert.AreEqual(true, original.BrokenNewSeqNo);
@@ -1492,7 +1492,7 @@ public class SessionTests : SessionTestsBase<Fix.Session>
         Assert.AreEqual("INITIATOR", clone.SenderCompId);
         Assert.AreEqual("ACCEPTOR", clone.TargetCompId);
         Assert.AreEqual(60, clone.HeartBtInt);
-        Assert.AreEqual(false, clone.MillisecondTimestamps);
+        Assert.AreEqual(Fix.Field.TimestampFormatShort, clone.OutgoingTimestampFormat);
         Assert.AreEqual(2, clone.IncomingSeqNum);
         Assert.AreEqual(2, clone.OutgoingSeqNum);
         Assert.AreEqual(false, clone.BrokenNewSeqNo);
@@ -1500,6 +1500,15 @@ public class SessionTests : SessionTestsBase<Fix.Session>
         Assert.AreEqual(false, clone.FragmentMessages);
         Assert.AreEqual(false, clone.AutoSendingTime);
         Assert.AreEqual(@"D:\other\path\file.session", clone.FileName);
+    }
+
+    [TestMethod]
+    public void TestInvalidOutgoingTimestampFormat()
+    {
+        var session = new Fix.Session();
+        Assert.AreEqual(Fix.Field.TimestampFormatLong, session.OutgoingTimestampFormat);
+        Assert.ThrowsException<Exception>(() => session.OutgoingTimestampFormat = "aaa");
+        Assert.AreEqual(Fix.Field.TimestampFormatLong, session.OutgoingTimestampFormat);
     }
 
     /*

--- a/Fix/Field.cs
+++ b/Fix/Field.cs
@@ -25,9 +25,22 @@ public class Field : ICloneable
     public const string TimestampFormatShort = "yyyyMMdd-HH:mm:ss";
     public const string TimestampFormatLong = "yyyyMMdd-HH:mm:ss.fff";
 
-    public static string TimeString(bool fractionalSeconds = false)
+    public static string TimestampString(string timestampFormat = TimestampFormatLong) => DateTime.UtcNow.ToString(timestampFormat);
+
+    public static bool IsTimestampFormatStringValid(string format)
     {
-        return DateTime.UtcNow.ToString(fractionalSeconds ? TimestampFormatLong : TimestampFormatShort);
+        try
+        {
+            var result = DateTime.ParseExact(DateTime.Now.ToString(format, CultureInfo.InvariantCulture),
+                                             format,
+                                             CultureInfo.InvariantCulture,
+                                             DateTimeStyles.NoCurrentDateDefault);
+            return result != default;
+        }
+        catch
+        {
+            return false;
+        }
     }
 
     public static readonly Field Invalid = new(0, string.Empty);

--- a/Fix/Session.Transport.cs
+++ b/Fix/Session.Transport.cs
@@ -168,7 +168,7 @@ public partial class Session
                 message.Fields.Set(FIX_5_0SP2.Fields.MsgSeqNum, AllocateOutgoingSeqNum());
             }
 
-            message.Fields.Set(FIX_5_0SP2.Fields.SendingTime, Field.TimeString(MillisecondTimestamps));
+            message.Fields.Set(FIX_5_0SP2.Fields.SendingTime, Field.TimestampString(OutgoingTimestampFormat));
 
             if (_writer != null)
             {

--- a/Fix/Session.cs
+++ b/Fix/Session.cs
@@ -44,6 +44,7 @@ public partial class Session : ICloneable
     Timer? _heartbeatTimer;
     Timer? _testRequestTimer;
     bool _logonReceived;
+    string _outgoingTimestampFormat = Field.TimestampFormatLong;
 
     #region Events
 
@@ -142,7 +143,7 @@ public partial class Session : ICloneable
         AutoSendingTime = true;
         OutgoingSeqNum = 1;
         IncomingSeqNum = 1;
-        MillisecondTimestamps = true;
+        OutgoingTimestampFormat = Field.TimestampFormatLong;
         FragmentMessages = true;
         TestRequestDelay = 2;
         ValidateDataFields = true;
@@ -160,7 +161,7 @@ public partial class Session : ICloneable
         SenderCompId = session.SenderCompId;
         TargetCompId = session.TargetCompId;
         HeartBtInt = session.HeartBtInt;
-        MillisecondTimestamps = session.MillisecondTimestamps;
+        OutgoingTimestampFormat = session.OutgoingTimestampFormat;
         IncomingSeqNum = session.IncomingSeqNum;
         OutgoingSeqNum = session.OutgoingSeqNum;
         BrokenNewSeqNo = session.BrokenNewSeqNo;
@@ -217,9 +218,19 @@ public partial class Session : ICloneable
     public int HeartBtInt { get; set; }
 
     [Category(CategoryCommon)]
-    [DisplayName("Millisecond Timestamps")]
+    [DisplayName("Outgoing Timestamp Format")]
     [JsonProperty]
-    public bool MillisecondTimestamps { get; set; }
+    public string OutgoingTimestampFormat { 
+        get => _outgoingTimestampFormat;
+        set
+        {
+            if (!Field.IsTimestampFormatStringValid(value))
+            {
+                throw new Exception($"'{value}' is not a valid DateTime format string");    
+            }
+            _outgoingTimestampFormat = value;
+        } 
+    }
 
     [Category(CategoryCommon)]
     [DisplayName("Incoming MsgSegNum")]

--- a/FixClient.Tests/SessionTests.cs
+++ b/FixClient.Tests/SessionTests.cs
@@ -123,7 +123,7 @@ public class SessionTests
         Assert.AreEqual("SENDER", original.SenderCompId);
         Assert.AreEqual("TARGET", original.TargetCompId);
         Assert.AreEqual(30, original.HeartBtInt);
-        Assert.AreEqual(true, original.OutgoingTimestampFormat);
+        Assert.AreEqual(Fix.Field.TimestampFormatLong, original.OutgoingTimestampFormat);
         Assert.AreEqual(1, original.IncomingSeqNum);
         Assert.AreEqual(1, original.OutgoingSeqNum);
         Assert.AreEqual(true, original.BrokenNewSeqNo);
@@ -158,7 +158,7 @@ public class SessionTests
         Assert.AreEqual("INITIATOR", clone.SenderCompId);
         Assert.AreEqual("ACCEPTOR", clone.TargetCompId);
         Assert.AreEqual(60, clone.HeartBtInt);
-        Assert.AreEqual(false, clone.OutgoingTimestampFormat);
+        Assert.AreEqual(Fix.Field.TimestampFormatShort, clone.OutgoingTimestampFormat);
         Assert.AreEqual(2, clone.IncomingSeqNum);
         Assert.AreEqual(2, clone.OutgoingSeqNum);
         Assert.AreEqual(false, clone.BrokenNewSeqNo);

--- a/FixClient.Tests/SessionTests.cs
+++ b/FixClient.Tests/SessionTests.cs
@@ -50,7 +50,7 @@ public class SessionTests
             SenderCompId = "SENDER",
             TargetCompId = "TARGET",
             HeartBtInt = 30,
-            MillisecondTimestamps = true,
+            OutgoingTimestampFormat = Fix.Field.TimestampFormatLong,
             IncomingSeqNum = 1,
             OutgoingSeqNum = 1,
             BrokenNewSeqNo = true,
@@ -88,7 +88,7 @@ public class SessionTests
         clone.SenderCompId = "INITIATOR";
         clone.TargetCompId = "ACCEPTOR";
         clone.HeartBtInt = 60;
-        clone.MillisecondTimestamps = false;
+        clone.OutgoingTimestampFormat = Fix.Field.TimestampFormatShort;
         clone.IncomingSeqNum = 2;
         clone.OutgoingSeqNum = 2;
         clone.BrokenNewSeqNo = false;
@@ -123,7 +123,7 @@ public class SessionTests
         Assert.AreEqual("SENDER", original.SenderCompId);
         Assert.AreEqual("TARGET", original.TargetCompId);
         Assert.AreEqual(30, original.HeartBtInt);
-        Assert.AreEqual(true, original.MillisecondTimestamps);
+        Assert.AreEqual(true, original.OutgoingTimestampFormat);
         Assert.AreEqual(1, original.IncomingSeqNum);
         Assert.AreEqual(1, original.OutgoingSeqNum);
         Assert.AreEqual(true, original.BrokenNewSeqNo);
@@ -158,7 +158,7 @@ public class SessionTests
         Assert.AreEqual("INITIATOR", clone.SenderCompId);
         Assert.AreEqual("ACCEPTOR", clone.TargetCompId);
         Assert.AreEqual(60, clone.HeartBtInt);
-        Assert.AreEqual(false, clone.MillisecondTimestamps);
+        Assert.AreEqual(false, clone.OutgoingTimestampFormat);
         Assert.AreEqual(2, clone.IncomingSeqNum);
         Assert.AreEqual(2, clone.OutgoingSeqNum);
         Assert.AreEqual(false, clone.BrokenNewSeqNo);

--- a/FixClient/CHANGELOG.TXT
+++ b/FixClient/CHANGELOG.TXT
@@ -2,16 +2,17 @@
 5.3.0
 
 •	Fixed an exception when adding custom fields.
+•	The format of outgoing timestamp fields can now be customised in the session properties dialog.
 
 --------------------------------------------------------------------------------
-5.2.0
+5.2.0		2022/12/11
 
 •	Upgrade to .NET 7.0
 •	Fix the value description column in the parser view.
 •	Replace the parser data grid with a text view that renders an order book inline with the FIX messages.
 
 --------------------------------------------------------------------------------
-5.0.0
+5.0.0		2021/07/18
 
 •	Replaced the FIX Repository based dictionary with one generated from the FIX Orchestra.
 	- Fields with with multi character enumerated values are now fully supported.

--- a/FixClient/MessagesPanel.cs
+++ b/FixClient/MessagesPanel.cs
@@ -1371,7 +1371,7 @@ partial class MessagesPanel : FixClientPanel
             int nextAllocId = Session.NextAllocId;
             int nextListSeqNo = 1;
             int index = 0;
-            string time = Fix.Field.TimeString(Session.MillisecondTimestamps);
+            string time = Fix.Field.TimestampString(Session.OutgoingTimestampFormat);
 
             foreach (Fix.Field field in message.Fields)
             {
@@ -1523,7 +1523,7 @@ partial class MessagesPanel : FixClientPanel
         if (_fieldTable == null)
             return;
 
-        string time = Fix.Field.TimeString(_session.MillisecondTimestamps);
+        string time = Fix.Field.TimestampString(_session.OutgoingTimestampFormat);
 
         foreach (FieldDataRow row in _fieldTable.Rows)
         {

--- a/FixClient/Orders/OrdersPanel.cs
+++ b/FixClient/Orders/OrdersPanel.cs
@@ -610,6 +610,11 @@ partial class OrdersPanel : FixClientPanel
 
         foreach (DataGridViewRow row in _orderGrid.Rows)
         {
+            if (_session is null)
+            {
+                return;
+            }
+
             try
             {
                 var view = row.DataBoundItem as DataRowView;
@@ -632,7 +637,7 @@ partial class OrdersPanel : FixClientPanel
 
                 MessagesPanel.UpdateMessage(message, order);
 
-                message.Fields.Set(FIX_5_0SP2.Fields.TransactTime, Fix.Field.TimeString(Session.MillisecondTimestamps));
+                message.Fields.Set(FIX_5_0SP2.Fields.TransactTime, Fix.Field.TimestampString(_session.OutgoingTimestampFormat));
 
                 if (order.Side is FieldValue side)
                 {

--- a/FixClient/Session.cs
+++ b/FixClient/Session.cs
@@ -313,7 +313,7 @@ public partial class Session : Fix.PersistentSession
         OnError(message);
     }
 
-    #endregion
+    #endregion 
 
     #region Custom Fields
 


### PR DESCRIPTION
Session.MillisecondTimestamps has been replaced with Session.OutgoingTimestampFormat which accepts a .NET DateTime format string. This can be customised in the Session options dialog.